### PR TITLE
Nextgen

### DIFF
--- a/bot.conf
+++ b/bot.conf
@@ -3,5 +3,3 @@ NICK = irclogbot_backup
 SERVER = irc.freenode.net
 # multiple channels on the same server should be separated by whitespace
 CHANNEL = \#perl6 \#bioclipse
-
-TIMEZONE = LOCAL

--- a/cgi/text.pl
+++ b/cgi/text.pl
@@ -10,6 +10,7 @@ use HTML::Entities;
 # evil hack: Text::Table lies somewhere near /irclog/ on the server...
 use lib '../lib';
 use lib 'lib';
+use Ilbot::Config qw/config/;
 use IrcLog qw(get_dbh gmt_today);
 use IrcLog::WWW qw(my_encode my_decode);
 use Text::Table;
@@ -55,15 +56,15 @@ my $table = Text::Table->new(qw(Time Nick Message));
 
 while (my $row = $db->fetchrow_hashref){
     next unless length($row->{nick});
-	my $conf = Config::File::read_config_file("bot.conf");
-    my $timezone = $conf->{TIMEZONE} || "GMT";
+
+	my $timezone = config(backend => 'timezone') || 'gmt';
 
     my ($hour, $minute);
 
-    if($timezone eq 'GMT') {
+    if($timezone eq 'gmt') {
         ($hour, $minute) =(gmtime $row->{timestamp})[2,1];
     }
-    elsif($timezone eq 'LOCAL') {
+    elsif($timezone eq 'local') {
         ($hour, $minute) =(localtime $row->{timestamp})[2,1];
     }
 

--- a/config/backend.conf.example
+++ b/config/backend.conf.example
@@ -7,3 +7,9 @@ database = moritz5
 host = localhost
 user = moritz
 password = foo
+
+# Timezone
+# Options:
+#	* 'local' for server's timezone
+#	* 'gmt' for UTC
+timezone = local

--- a/lib/Ilbot/Config.pm
+++ b/lib/Ilbot/Config.pm
@@ -19,6 +19,9 @@ my %defaults = (
         base_url    => '/',
         no_cache    => 0,
     },
+    backend => {
+        timzone    => 'local',
+    },
 );
 
 sub import {

--- a/lib/Ilbot/Date.pm
+++ b/lib/Ilbot/Date.pm
@@ -2,20 +2,20 @@ package Ilbot::Date;
 use strict;
 use warnings;
 use 5.010;
+use Ilbot::Config qw/config/;
 
 use Exporter qw/import/;
 
 our @EXPORT_OK = qw/gmt_today/;
 
-# returns current date in GMT in the form YYYY-MM-DD
+# returns current date in gmt or local timezone in the form YYYY-MM-DD
 sub gmt_today {
-	my $conf = Config::File::read_config_file("bot.conf");
-    my $timezone = $conf->{TIMEZONE} || "GMT";
+	my $timezone = config(backend => 'timezone') || 'gmt';
 
     my @d;
 
-    if($timezone eq 'GMT') { @d = gmtime(time); }
-    elsif($timezone eq 'LOCAL') { @d = localtime(time); }
+    if($timezone eq 'gmt') { @d = gmtime(time); }
+    elsif($timezone eq 'local') { @d = localtime(time); }
 
     return sprintf("%04d-%02d-%02d", $d[5]+1900, $d[4] + 1, $d[3]);
 }

--- a/lib/Ilbot/Frontend.pm
+++ b/lib/Ilbot/Frontend.pm
@@ -231,15 +231,14 @@ sub day_text {
     for my $row (@{ $self->backend->channel(channel => "#$channel")->lines(day => $opt{day}) }) {
         my ($nick, $ts, $line) = ($row->[1], $row->[2], $row->[3]);
 
-		my $conf = Config::File::read_config_file("bot.conf");
-		my $timezone = $conf->{TIMEZONE} || "GMT";
+		my $timezone = config(backend => 'timezone') || 'gmt';
 
 		my ($hour, $minute);
 
-		if($timezone eq 'GMT') {
+		if($timezone eq 'gmt') {
         	($hour, $minute) = (gmtime $ts)[2, 1];
 		}
-		elsif($timezone eq 'LOCAL') {
+		elsif($timezone eq 'local') {
         	($hour, $minute) = (localtime $ts)[2, 1];
 		}
 
@@ -340,13 +339,12 @@ sub http_header {
 sub format_time {
     my $d = shift;
 	
-	my $conf = Config::File::read_config_file("bot.conf");
-    my $timezone = $conf->{TIMEZONE} || "GMT";
+	my $timezone = config(backend => 'timezone') || 'gmt';
 
     my @times;
 
-    if($timezone eq 'GMT') { @times = gmtime($d); }
-    elsif($timezone eq 'LOCAL') { @times = localtime($d); }
+    if($timezone eq 'gmt') { @times = gmtime($d); }
+    elsif($timezone eq 'local') { @times = localtime($d); }
 
     return sprintf("%02d:%02d", $times[2], $times[1]);
 }

--- a/lib/IrcLog.pm
+++ b/lib/IrcLog.pm
@@ -7,6 +7,7 @@ use DBI;
 use Config::File;
 use Carp;
 use utf8;
+use Ilbot::Config qw/config/;
 
 require Exporter;
 
@@ -32,15 +33,14 @@ sub get_dbh {
     return $dbh;
 }
 
-# returns current date in GMT or EST in the form YYYY-MM-DD
+# returns current date in gmt or local time zone in the form YYYY-MM-DD
 sub gmt_today {
-    my $conf = Config::File::read_config_file("bot.conf");
-    my $timezone = $conf->{TIMEZONE} || "GMT";
+	my $timezone = config(backend => 'timezone') || 'gmt';
 
 	my @d;
 
-	if($timezone eq 'GMT') { @d = gmtime(time); }
-	elsif($timezone eq 'LOCAL') { @d = localtime(time); }
+	if($timezone eq 'gmt') { @d = gmtime(time); }
+	elsif($timezone eq 'local') { @d = localtime(time); }
 
     return sprintf("%04d-%02d-%02d", $d[5]+1900, $d[4] + 1, $d[3]);
 }

--- a/lib/IrcLog/WWW.pm
+++ b/lib/IrcLog/WWW.pm
@@ -7,6 +7,7 @@ use HTML::Entities;
 use POSIX qw(ceil);
 use Config::File;
 use Carp qw(confess cluck);
+use Ilbot::Config qw/config/;
 use utf8;
 
 use base 'Exporter';
@@ -53,13 +54,12 @@ sub decode_by_guessing {
 # turns a timestap into a (GMT) or LOCAL time string
 sub format_time {
     my $d = shift;
-	my $conf = Config::File::read_config_file("bot.conf");
-    my $timezone = $conf->{TIMEZONE} || "GMT";
+	my $timezone = config(backend => 'timezone') || 'gmt';
 
     my @times;
 
-    if($timezone eq 'GMT') { @times = gmtime($d); }
-    elsif($timezone eq 'LOCAL') { @times = localtime($d); }
+    if($timezone eq 'gmt') { @times = gmtime($d); }
+    elsif($timezone eq 'local') { @times = localtime($d); }
 
     return sprintf("%02d:%02d", $times[2], $times[1]);
 }

--- a/t/revision-links.t
+++ b/t/revision-links.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Config::File;
+use Ilbot::Config qw/config/;
 use Test::More tests => 6;
 
 BEGIN { use_ok('IrcLog::WWW'); }
@@ -9,11 +9,10 @@ sub link_text {
     my $text = shift;
     my $c = 1;
 
-	my $conf = Config::File::read_config_file("bot.conf");
-    my $timezone = $conf->{TIMEZONE} || "GMT";
+	my $timezone = config(backend => 'timezone') || 'gmt';
     my $time;
-    if($timezone eq 'GMT') { $time = gmtime; }
-    elsif($timezone eq 'LOCAL') { $time = localtime; }
+    if($timezone eq 'gmt') { $time = gmtime; }
+    elsif($timezone eq 'local') { $time = localtime; }
 
     my $h = IrcLog::WWW::message_line({
             id          => 1,

--- a/t/synopsis-links.t
+++ b/t/synopsis-links.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Config::Time;
+use Ilbot::Config qw/config/;
 use Test::More tests => 9;
 
 BEGIN { use_ok('IrcLog::WWW'); }
@@ -9,11 +9,10 @@ sub link_length {
     my $text = shift;
     my $c = 1;
 
-	my $conf = Config::File::read_config_file("bot.conf");
-    my $timezone = $conf->{TIMEZONE} || "GMT";
+	my $timezone = config(backend => 'timezone') || 'gmt';
     my $time;
-    if($timezone eq 'GMT') { $time = gmtime; }
-    elsif($timezone eq 'LOCAL') { $time = localtime; }
+    if($timezone eq 'gmt') { $time = gmtime; }
+    elsif($timezone eq 'local') { $time = localtime; }
 
     my $h = IrcLog::WWW::message_line({
             id          => 1,


### PR DESCRIPTION
Added the TIMEZONE config parameter to the bot.conf file, and then added an option to use it everywhere gmtime was used.

Tested this on my own installation by modifying the files (which were present at least - I know a few have been added to the nextgen) and it works.
