### PR TITLE
Implement per-channel configurable issue trackers (Closes #39)

### DIFF
--- a/config/www.conf.example
+++ b/config/www.conf.example
@@ -8,3 +8,5 @@ logo_alt  = Camelia, the Perl 6 bug # Site default
 chan_conf[bottest][logo_url]   = http://example.com/logo.jpg # for #bottest
 chan_conf[bottest][logo_link]  = http://example.com/         # for #bottest
 chan_conf[bottest][logo_alt]   = Custom channel logo alt=""  # for #bottest
+chan_conf[bottest][tracker][github]  = https://github.com/parrot/parrot/
+chan_conf[bottest][tracker][default] = GH # RT is the other default


### PR DESCRIPTION
Here's the behaviour implemented:
* `RT #\d+` will always link to RT
* If `chan_conf[CHANNEL][tracker][github]` is set, that URL will be used to link to anything that's marked as 'PR', 'GH', or 'pull request' in the channel
* If `chan_conf[CHANNEL][tracker][github]` is set AND If `chan_conf[CHANNEL][tracker][default]` is set to value `GH`, all plain references to `#\d+` will be linked to GitHub repo as well
* If `chan_conf[CHANNEL][tracker][default]` is set to value `RT`, all plain references to `#\d+` will be linked to RT

PS: I link both GH PRs and Issues to `/issues/` because that works
PPS: I removed hardcoded parot and moe repo links; those will need to be configured now