### PR TITLE
Fix minor CSS clipping bug

### DIFF
--- a/static/s/style.css
+++ b/static/s/style.css
@@ -81,14 +81,14 @@ tr, td {
 
 label,input {
 	display: block;
-	width: 10em;
+	min-width: 10em;
 	float: left;
 	margin-bottom: 2ex;
 }
 
 label {
 	text-align: right;
-	width: 8em;
+	min-width: 8em;
 	padding-right: 2ex;
 }
 


### PR DESCRIPTION
The button text "Look for new lines (r)" is slightly wider than 10em on my browser. I'm guessing it probably looked okay when it was originally written due to UAs having slight differences in form control padding.